### PR TITLE
don't build on intel macos-13

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -52,8 +52,6 @@ jobs:
             os: ubuntu
           - runner: self-hosted
             os: macos
-          - runner: macos-13
-            os: macos
 
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -50,7 +50,7 @@ jobs:
             os: ubuntu
           - runner: [runs-on, runner=32cpu-linux-arm64, "run-id=${{ github.run_id }}"]
             os: ubuntu
-          - runner: self-hosted
+          - runner: macos-latest
             os: macos
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
         runner:
           - [runs-on, runner=32cpu-linux-x64, "run-id=${{ github.run_id }}"]
           - [runs-on, runner=32cpu-linux-arm64, "run-id=${{ github.run_id }}"]
-          - self-hosted
-          - macos-13
+          - macos-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Install nightly toolchain


### PR DESCRIPTION
The riscv-tools can't be installed and the release fails. Building on Intel Mac can be re-enabled in the future once #10 is fixed.